### PR TITLE
Updated git clone links for proper setup experience in obj_localize_beta branch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ env:
   global:
     - DOCKER_IMAGE='cardboardcode/epd-foxy-base:latest'
     - PARALLEL_TESTS=true  # Global Variable
+    - CODE_COVERAGE="codecov.io"
+    - CODECOV_TOKEN="bfb1cab5-ed38-473e-b4e9-ac42cf65a51a"
 
   matrix:
     - ROS_DISTRO="foxy" ROS_REPO=testing BEFORE_INIT="echo 'deb http://packages.ros.org/ros2-testing/ubuntu focal main' > /etc/apt/sources.list.d/ros2-latest.list"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ env:
     - ROS_DISTRO="foxy" ROS_REPO=main
 
 install:
-  - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci -b master
+  - git clone --quiet --depth 1 https://github.com/Briancbn/industrial_ci .industrial_ci -b pr-coverage
 script:
   - .industrial_ci/travis.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 # **easy_perception_deployment**
-[![Build Status](https://travis-ci.org/cardboardcode/easy_perception_deployment.svg?branch=master)](https://travis-ci.org/cardboardcode/easy_perception_deployment)[![codecov](https://codecov.io/gh/cardboardcode/easy_perception_deployment/branch/master/graph/badge.svg)](https://codecov.io/gh/cardboardcode/easy_perception_deployment)
+[![Build Status](https://travis-ci.org/cardboardcode/easy_perception_deployment.svg?branch=obj_localize_beta)](https://travis-ci.org/cardboardcode/easy_perception_deployment)[![codecov](https://codecov.io/gh/cardboardcode/easy_perception_deployment/branch/master/graph/badge.svg)](https://codecov.io/gh/cardboardcode/easy_perception_deployment)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 
@@ -12,7 +12,7 @@ To get started using it, please run the following commands to start **viewing th
 ``` bash
 cd $HOME
 mkdir -p epd_ros2_ws/src && cd epd_ros2_ws/src
-git clone https://gitlab.com/ROSI-AP/rosi-ap_rect/easy_perception_deployment
+git clone https://github.com/cardboardcode/easy_perception_deployment.git --branch obj_localize_beta
 firefox /docs/_build/html/index.html
 ```
 
@@ -24,7 +24,7 @@ This section lists steps on how to build **easy_perception_deployment** package 
 # Download easy_perception_deployment
 cd $HOME
 mkdir -p epd_ros2_ws/src && cd epd_ros2_ws/src
-git clone https://gitlab.com/ROSI-AP/rosi-ap_rect/easy_perception_deployment
+git clone https://github.com/cardboardcode/easy_perception_deployment.git --branch obj_localize_beta
 cd easy_perception_deployment/easy_perception_deployment
 bash run.bash
 ```


### PR DESCRIPTION
This pull request does the following:
1. Replaces the unusable Gitlab clone links with the proper Github clone links.
2. Added automatic code coverage generation feature within travis CI builds.