### PR TITLE
Fix for defunct generic model download links and TrainFarm-Exporter Automatic Setup

### DIFF
--- a/easy_perception_deployment/gui/trainer/exporter_files/scripts/install_p2exporter.bash
+++ b/easy_perception_deployment/gui/trainer/exporter_files/scripts/install_p2exporter.bash
@@ -36,13 +36,13 @@ then
       python3 setup.py build develop
 
       # Install pycocotools
-      git clone https://github.com/cocodataset/cocoapi.git
+      git clone https://github.com/cardboardcode/cocoapi.git
       cd cocoapi/PythonAPI
       python3 setup.py build_ext install
 
       # Install apex
       cd $INSTALL_DIR
-      git clone https://github.com/NVIDIA/apex.git
+      git clone https://github.com/cardboardcode/apex.git
       cd apex
       python3 setup.py install
 

--- a/easy_perception_deployment/gui/trainer/exporter_files/scripts/install_p3exporter.bash
+++ b/easy_perception_deployment/gui/trainer/exporter_files/scripts/install_p3exporter.bash
@@ -37,13 +37,13 @@ then
       python3 setup.py build develop
 
       # Install pycocotools
-      git clone https://github.com/cocodataset/cocoapi.git
+      git clone https://github.com/cardboardcode/cocoapi.git
       cd cocoapi/PythonAPI
       python3 setup.py build_ext install
 
       # Install apex
       cd $INSTALL_DIR
-      git clone https://github.com/NVIDIA/apex.git
+      git clone https://github.com/cardboardcode/apex.git
       cd apex
       python3 setup.py install
 

--- a/easy_perception_deployment/gui/trainer/training_files/scripts/install_p2trainfarm.bash
+++ b/easy_perception_deployment/gui/trainer/training_files/scripts/install_p2trainfarm.bash
@@ -37,19 +37,19 @@ then
       export INSTALL_DIR=$PWD
 
       # Install pycocotools
-      git clone https://github.com/cocodataset/cocoapi.git
+      git clone https://github.com/cardboardcode/cocoapi.git
       cd cocoapi/PythonAPI
       python3 setup.py build_ext install
 
       # Install cityscapeScripts
       cd $INSTALL_DIR
-      git clone https://github.com/mcordts/cityscapesScripts.git
+      git clone https://github.com/cardboardcode/cityscapesScripts.git
       cd cityscapesScripts/
       python3 setup.py build_ext install
 
       # Install apex
       cd $INSTALL_DIR
-      git clone https://github.com/NVIDIA/apex.git
+      git clone https://github.com/cardboardcode/apex.git
       cd apex
       python3 setup.py install
 

--- a/easy_perception_deployment/gui/trainer/training_files/scripts/install_p3trainfarm.bash
+++ b/easy_perception_deployment/gui/trainer/training_files/scripts/install_p3trainfarm.bash
@@ -37,19 +37,19 @@ then
       export INSTALL_DIR=$PWD
 
       # Install pycocotools
-      git clone https://github.com/cocodataset/cocoapi.git
+      git clone https://github.com/cardboardcode/cocoapi.git
       cd cocoapi/PythonAPI
       python3 setup.py build_ext install
 
       # Install cityscapeScripts
       cd $INSTALL_DIR
-      git clone https://github.com/mcordts/cityscapesScripts.git
+      git clone https://github.com/cardboardcode/cityscapesScripts.git
       cd cityscapesScripts/
       python3 setup.py build_ext install
 
       # Install apex
       cd $INSTALL_DIR
-      git clone https://github.com/NVIDIA/apex.git
+      git clone https://github.com/cardboardcode/apex.git
       cd apex
       python3 setup.py install
 

--- a/easy_perception_deployment/run.bash
+++ b/easy_perception_deployment/run.bash
@@ -33,7 +33,7 @@ P1FILE=./data/model/squeezenet1.1-7.onnx
 if [ ! -f "$P1FILE" ]; then
     echo "Downloading $P1FILE."
     wget \
-    https://github.com/onnx/models/raw/master/vision/classification/squeezenet/model/squeezenet1.1-7.onnx \
+    https://github.com/onnx/models/raw/main/vision/classification/squeezenet/model/squeezenet1.1-7.onnx \
     --directory-prefix=./data/model/
 fi
 unset P1FILE
@@ -42,7 +42,7 @@ P2FILE=./data/model/FasterRCNN-10.onnx
 if [ ! -f "$P2FILE" ]; then
     echo "Downloading $P2FILE."
     wget \
-    https://github.com/onnx/models/raw/master/vision/object_detection_segmentation/faster-rcnn/model/FasterRCNN-10.onnx \
+    https://github.com/onnx/models/raw/main/vision/object_detection_segmentation/faster-rcnn/model/FasterRCNN-10.onnx \
     --directory-prefix=./data/model/
 fi
 unset P2FILE
@@ -51,7 +51,7 @@ P3FILE=./data/model/MaskRCNN-10.onnx
 if [ ! -f "$P3FILE" ]; then
     echo "Downloading $P3FILE."
     wget \
-    https://github.com/onnx/models/raw/master/vision/object_detection_segmentation/mask-rcnn/model/MaskRCNN-10.onnx \
+    https://github.com/onnx/models/raw/main/vision/object_detection_segmentation/mask-rcnn/model/MaskRCNN-10.onnx \
     --directory-prefix=./data/model/
 fi
 unset P3FILE


### PR DESCRIPTION
## What Is This For?

This pull request is to address defunct download links included in the follow bash automation scripts that affects the use of EPD.

1. Changes made to p1, p2 and p3 default generic models in `run.bash`. [onnx/model_zoo changed their master branch to main, affecting the url]
2. Changes made to `install_p2exporter` and `install_p3exporter`. [Nvidia/apex dependency is no longer compatible with current exporter builds. Using preserved repo instead.]
3. Changes made to `install_p2trainfarm` and `install_p3trainfarm`. [Nvidia/apex dependency is no longer compatible with current trainfarm builds. Using preserved repo instead.]