### PR TITLE
Removed .readthedocs.yaml & added link to Quality Declarations.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ easy_perception_deployment/gui/trainer/P3TrainFarm/*
 epd_msgs/build/*
 epd_msgs/log/*
 epd_msgs/install/*
-docs/_build/*
 
 # testing or other data
 *.mp4

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,0 @@
-build:
-  image: latest
-
-python:
-  version: 3.6
-  install:
-    - requirements: docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## **Quality Declaration**
 
-This package claims to be in the **Quality Level 4** category, see the **Quality Declaration** for more details.
+This package claims to be in the **Quality Level 4** category, see the [**Quality Declaration**](https://github.com/cardboardcode/easy_perception_deployment/blob/master/QUALITY_DECLARATION.md) for more details.
 
 ## **Setup**
 


### PR DESCRIPTION
## What Is This For?

This pull request is for introducing the aforementioned edits. This request comes in line with **epd_docs** Pull Request ros-industrial/epd_docs#2 that updates the EPD documentation.

## Edits
1. Removed redundant `.readthedocs.yaml` since docs has been shifted to separate GitHub repository.
2. Added link to Quality Declarations in root `README.md` instead of just bolding it.