### PR TITLE
Reverted useof built-in QoS for Visualizer mode.

### DIFF
--- a/easy_perception_deployment/include/epd_utils_lib/processor.hpp
+++ b/easy_perception_deployment/include/epd_utils_lib/processor.hpp
@@ -185,7 +185,7 @@ Processor::Processor(void)
   // Creating Publisher to output Visualizable P2 and P3 Detection Results.
   visual_pub = this->create_publisher<sensor_msgs::msg::Image>(
     "/processor/output",
-    rclcpp::SensorDataQoS());
+    10);
   // Creating Publisher to output Action P1 Detection Results.
   p1_pub = this->create_publisher<epd_msgs::msg::EPDImageClassification>(
     "/processor/epd_p1_output",


### PR DESCRIPTION
## What Is This For?
This pull request is to introduce a quick but long-term fix for issues displaying output images when EPD is running in visualize mode.

