### PR TITLE
Refactored main node name for easier system operation.

### DIFF
--- a/easy_perception_deployment/CMakeLists.txt
+++ b/easy_perception_deployment/CMakeLists.txt
@@ -153,15 +153,15 @@ if(BUILD_TESTING)
   ament_target_dependencies(epd_test_P3_tracking_action OpenCV cv_bridge)
   target_link_libraries(epd_test_P3_tracking_action ${onnxruntime_LIBS})
 
-  ament_add_gtest(epd_test_processor test/test_processor.cpp ${EPD_UTILS})
-  ament_target_dependencies(epd_test_processor rclcpp std_msgs sensor_msgs epd_msgs OpenCV cv_bridge message_filters pcl_conversions)
-  target_link_libraries(epd_test_processor ${onnxruntime_LIBS})
+  ament_add_gtest(epd_test_easy_perception_deployment test/test_easy_perception_deployment.cpp ${EPD_UTILS})
+  ament_target_dependencies(epd_test_easy_perception_deployment rclcpp std_msgs sensor_msgs epd_msgs OpenCV cv_bridge message_filters pcl_conversions)
+  target_link_libraries(epd_test_easy_perception_deployment ${onnxruntime_LIBS})
 
 endif()
 
-add_executable(processor src/processor.cpp ${EPD_UTILS})
+add_executable(easy_perception_deployment src/main.cpp ${EPD_UTILS})
 ament_target_dependencies(
-  processor
+  easy_perception_deployment
   rclcpp
   std_msgs
   sensor_msgs
@@ -172,11 +172,11 @@ ament_target_dependencies(
   message_filters
   pcl_conversions
 )
-target_link_libraries(processor ${onnxruntime_LIBS} ${PCL_LIBRARIES})
+target_link_libraries(easy_perception_deployment ${onnxruntime_LIBS} ${PCL_LIBRARIES})
 
 
 install(TARGETS
-  processor
+  easy_perception_deployment
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/easy_perception_deployment/gui/scripts/deploy.sh
+++ b/easy_perception_deployment/gui/scripts/deploy.sh
@@ -87,7 +87,7 @@ if [ "$showImage" = True ] ; then
       source /opt/ros/foxy/setup.bash
   fi
 
-  ros2 run image_tools showimage --ros-args --remap /image:=/processor/output > /dev/null 2>&1 &
+  ros2 run image_tools showimage --ros-args --remap /image:=/easy_perception_deployment/output > /dev/null 2>&1 &
 fi
 
 START_DIR=$(pwd)

--- a/easy_perception_deployment/include/epd_utils_lib/easy_perception_deployment.hpp
+++ b/easy_perception_deployment/include/epd_utils_lib/easy_perception_deployment.hpp
@@ -49,17 +49,17 @@
 #include "epd_utils_lib/message_utils.hpp"
 
 #include "pcl_conversions/pcl_conversions.h"
-/*! \class Processor
-    \brief An Processor class object.
+/*! \class EasyPerceptionDeployment
+    \brief An EasyPerceptionDeployment class object.
     This class object inherits rclcpp::Node object and acts the main bridge
     between the ROS2 interface and the underlying ort_cpp_lib library that is
     based on ONNXRuntime Library.
 */
-class Processor : public rclcpp::Node
+class EasyPerceptionDeployment : public rclcpp::Node
 {
 public:
   /*! \brief A Constructor function*/
-  Processor(void);
+  EasyPerceptionDeployment(void);
   /*! \brief A function that abstracts processing of input image in image_callback.*/
   void process_image_callback(const sensor_msgs::msg::Image::SharedPtr msg) const;
   /*! \brief A function that abstracts processing of input image in localize_callback.*/
@@ -169,7 +169,7 @@ private:
     const int img_width) const;
 };
 
-Processor::Processor(void)
+EasyPerceptionDeployment::EasyPerceptionDeployment(void)
 : Node("easy_perception_deployment"),
   localize_image_rgb(this, "/camera/color/image_raw"),
   localize_image_depth(this, "/camera/depth/image_rect_raw"),
@@ -180,7 +180,7 @@ Processor::Processor(void)
   image_sub = this->create_subscription<sensor_msgs::msg::Image>(
     "/easy_perception_deployment/image_input",
     rclcpp::SensorDataQoS(),
-    std::bind(&Processor::image_callback, this, std::placeholders::_1));
+    std::bind(&EasyPerceptionDeployment::image_callback, this, std::placeholders::_1));
 
   // Creating Publisher to output Visualizable P2 and P3 Detection Results.
   visual_pub = this->create_publisher<sensor_msgs::msg::Image>(
@@ -213,13 +213,13 @@ Processor::Processor(void)
     localize_image_rgb.subscribe();
     localize_image_depth.subscribe();
     localize_cam_info.subscribe();
-    sync_.registerCallback(&Processor::localize_callback, this);
+    sync_.registerCallback(&EasyPerceptionDeployment::localize_callback, this);
     image_sub.reset();
   } else if (ortAgent_.useCaseMode == 4) {
     localize_image_rgb.subscribe();
     localize_image_depth.subscribe();
     localize_cam_info.subscribe();
-    sync_.registerCallback(&Processor::tracking_callback, this);
+    sync_.registerCallback(&EasyPerceptionDeployment::tracking_callback, this);
     image_sub.reset();
   } else {
     localize_image_rgb.unsubscribe();
@@ -249,17 +249,17 @@ Processor::Processor(void)
         localize_image_rgb.subscribe();
         localize_image_depth.subscribe();
         localize_cam_info.subscribe();
-        sync_.registerCallback(&Processor::localize_callback, this);
+        sync_.registerCallback(&EasyPerceptionDeployment::localize_callback, this);
       } else if (ortAgent_.useCaseMode == 4) {
         localize_image_rgb.subscribe();
         localize_image_depth.subscribe();
         localize_cam_info.subscribe();
-        sync_.registerCallback(&Processor::tracking_callback, this);
+        sync_.registerCallback(&EasyPerceptionDeployment::tracking_callback, this);
       } else {
         image_sub = this->create_subscription<sensor_msgs::msg::Image>(
           "/easy_perception_deployment/image_input",
           10,
-          std::bind(&Processor::image_callback, this, std::placeholders::_1));
+          std::bind(&EasyPerceptionDeployment::image_callback, this, std::placeholders::_1));
       }
 
       ortAgent_.requestAddressed = false;
@@ -270,7 +270,7 @@ Processor::Processor(void)
     handle_emd_request);
 }
 
-void Processor::hasCameraChanged(const int img_height, const int img_width) const
+void EasyPerceptionDeployment::hasCameraChanged(const int img_height, const int img_width) const
 {
   // TODO(cardboardcode) Implement auto reinitialization of Ort Session.
   /*
@@ -283,7 +283,7 @@ void Processor::hasCameraChanged(const int img_height, const int img_width) cons
   }
 }
 
-void Processor::checkOrtAgentIsInitialized(const int img_height, const int img_width) const
+void EasyPerceptionDeployment::checkOrtAgentIsInitialized(const int img_height, const int img_width) const
 {
   if (!ortAgent_.isInit()) {
     ortAgent_.setFrameDimension(img_width, img_height);
@@ -294,7 +294,7 @@ void Processor::checkOrtAgentIsInitialized(const int img_height, const int img_w
   }
 }
 
-void Processor::process_localize_callback(
+void EasyPerceptionDeployment::process_localize_callback(
   const sensor_msgs::msg::Image::SharedPtr msg,
   const sensor_msgs::msg::Image::SharedPtr depth_msg,
   const sensor_msgs::msg::CameraInfo::SharedPtr camera_info)
@@ -405,7 +405,7 @@ void Processor::process_localize_callback(
 // WARNING: The use of message filter sychronization causes the intake of image
 // from a realsense D415 or D435 camera to be irregular. In other words, this callback cannot
 // be called at a fixed interval.
-void Processor::localize_callback(
+void EasyPerceptionDeployment::localize_callback(
   const sensor_msgs::msg::Image::SharedPtr msg,
   const sensor_msgs::msg::Image::SharedPtr depth_msg,
   const sensor_msgs::msg::CameraInfo::SharedPtr camera_info)
@@ -413,7 +413,7 @@ void Processor::localize_callback(
   this->process_localize_callback(msg, depth_msg, camera_info);
 }
 
-void Processor::process_tracking_callback(
+void EasyPerceptionDeployment::process_tracking_callback(
   const sensor_msgs::msg::Image::SharedPtr msg,
   const sensor_msgs::msg::Image::SharedPtr depth_msg,
   const sensor_msgs::msg::CameraInfo::SharedPtr camera_info)
@@ -547,7 +547,7 @@ void Processor::process_tracking_callback(
   }
 }
 
-void Processor::tracking_callback(
+void EasyPerceptionDeployment::tracking_callback(
   const sensor_msgs::msg::Image::SharedPtr msg,
   const sensor_msgs::msg::Image::SharedPtr depth_msg,
   const sensor_msgs::msg::CameraInfo::SharedPtr camera_info)
@@ -555,7 +555,7 @@ void Processor::tracking_callback(
   this->process_tracking_callback(msg, depth_msg, camera_info);
 }
 
-void Processor::process_image_callback(const sensor_msgs::msg::Image::SharedPtr msg) const
+void EasyPerceptionDeployment::process_image_callback(const sensor_msgs::msg::Image::SharedPtr msg) const
 {
   /* Check if input image is empty or not.
   If empty, discard image and don't process.
@@ -657,9 +657,9 @@ void Processor::process_image_callback(const sensor_msgs::msg::Image::SharedPtr 
   RCLCPP_INFO(this->get_logger(), "[-FPS-]= %f\n", 1000.0 / elapsedTime.count());
 }
 
-void Processor::image_callback(const sensor_msgs::msg::Image::SharedPtr msg) const
+void EasyPerceptionDeployment::image_callback(const sensor_msgs::msg::Image::SharedPtr msg) const
 {
   this->process_image_callback(msg);
 }
 
-#endif  // EPD_UTILS_LIB__PROCESSOR_HPP_
+#endif  // EPD_UTILS_LIB__EASY_PERCEPTION_DEPLOYMENT_HPP_

--- a/easy_perception_deployment/include/epd_utils_lib/easy_perception_deployment.hpp
+++ b/easy_perception_deployment/include/epd_utils_lib/easy_perception_deployment.hpp
@@ -14,8 +14,8 @@
 // limitations under the License.
 
 
-#ifndef EPD_UTILS_LIB__PROCESSOR_HPP_
-#define EPD_UTILS_LIB__PROCESSOR_HPP_
+#ifndef EPD_UTILS_LIB__EASY_PERCEPTION_DEPLOYMENT_HPP_
+#define EPD_UTILS_LIB__EASY_PERCEPTION_DEPLOYMENT_HPP_
 
 #include <chrono>
 #include <string>
@@ -170,7 +170,7 @@ private:
 };
 
 Processor::Processor(void)
-: Node("processor"),
+: Node("easy_perception_deployment"),
   localize_image_rgb(this, "/camera/color/image_raw"),
   localize_image_depth(this, "/camera/depth/image_rect_raw"),
   localize_cam_info(this, "/camera/color/camera_info"),
@@ -178,33 +178,33 @@ Processor::Processor(void)
 {
   // Creating Subscriber to get Input Image.
   image_sub = this->create_subscription<sensor_msgs::msg::Image>(
-    "/processor/image_input",
+    "/easy_perception_deployment/image_input",
     rclcpp::SensorDataQoS(),
     std::bind(&Processor::image_callback, this, std::placeholders::_1));
 
   // Creating Publisher to output Visualizable P2 and P3 Detection Results.
   visual_pub = this->create_publisher<sensor_msgs::msg::Image>(
-    "/processor/output",
+    "/easy_perception_deployment/image_output",
     10);
   // Creating Publisher to output Action P1 Detection Results.
   p1_pub = this->create_publisher<epd_msgs::msg::EPDImageClassification>(
-    "/processor/epd_p1_output",
+    "/easy_perception_deployment/epd_p1_output",
     10);
   // Creating Publisher to output Action P2 Detection Results.
   p2_pub = this->create_publisher<epd_msgs::msg::EPDObjectDetection>(
-    "/processor/epd_p2_output",
+    "/easy_perception_deployment/epd_p2_output",
     10);
   // Creating Publisher to output Action P3 Detection Results.
   p3_pub = this->create_publisher<epd_msgs::msg::EPDObjectDetection>(
-    "/processor/epd_p3_output",
+    "/easy_perception_deployment/epd_p3_output",
     10);
   // Creating Publisher to output Action P3 and Localization Detection Results.
   localize_pub = this->create_publisher<epd_msgs::msg::EPDObjectLocalization>(
-    "/processor/epd_localize_output",
+    "/easy_perception_deployment/epd_localize_output",
     10);
   // Creating Publisher to output Action P3 and Tracking Detection Results.
   tracking_pub = this->create_publisher<epd_msgs::msg::EPDObjectTracking>(
-    "/processor/epd_tracking_output",
+    "/easy_perception_deployment/epd_tracking_output",
     10);
 
   // If useCaseMode is detected to be Localization or Tracking,
@@ -257,7 +257,7 @@ Processor::Processor(void)
         sync_.registerCallback(&Processor::tracking_callback, this);
       } else {
         image_sub = this->create_subscription<sensor_msgs::msg::Image>(
-          "/processor/image_input",
+          "/easy_perception_deployment/image_input",
           10,
           std::bind(&Processor::image_callback, this, std::placeholders::_1));
       }

--- a/easy_perception_deployment/include/epd_utils_lib/easy_perception_deployment.hpp
+++ b/easy_perception_deployment/include/epd_utils_lib/easy_perception_deployment.hpp
@@ -283,7 +283,9 @@ void EasyPerceptionDeployment::hasCameraChanged(const int img_height, const int 
   }
 }
 
-void EasyPerceptionDeployment::checkOrtAgentIsInitialized(const int img_height, const int img_width) const
+void EasyPerceptionDeployment::checkOrtAgentIsInitialized(
+  const int img_height,
+  const int img_width) const
 {
   if (!ortAgent_.isInit()) {
     ortAgent_.setFrameDimension(img_width, img_height);
@@ -555,7 +557,8 @@ void EasyPerceptionDeployment::tracking_callback(
   this->process_tracking_callback(msg, depth_msg, camera_info);
 }
 
-void EasyPerceptionDeployment::process_image_callback(const sensor_msgs::msg::Image::SharedPtr msg) const
+void EasyPerceptionDeployment::process_image_callback(const sensor_msgs::msg::Image::SharedPtr msg)
+const
 {
   /* Check if input image is empty or not.
   If empty, discard image and don't process.

--- a/easy_perception_deployment/include/epd_utils_lib/message_utils.hpp
+++ b/easy_perception_deployment/include/epd_utils_lib/message_utils.hpp
@@ -32,7 +32,7 @@ namespace EPD
 /*! \class EPDObjectDetection
     \brief An Easy Perception Deployment (EPD) ObjectDetection class object.
     This object functions as a transient container of inference results to
-    transport them for processing in by Processor class object.
+    transport them for processing in by EasyPerceptionDeployment class object.
 */
 class EPDObjectDetection
 {

--- a/easy_perception_deployment/include/ort_cpp_lib/p1_ort_base.hpp
+++ b/easy_perception_deployment/include/ort_cpp_lib/p1_ort_base.hpp
@@ -70,7 +70,7 @@ private:
   /*! \brief The number of object text labels given an input label list.*/
   const uint16_t m_numClasses;
   /*! \brief The aspect ratio calculated from the dimension of an input image
-  frame, which is provided when the first input image is received by Processor.*/
+  frame, which is provided when the first input image is received by EasyPerceptionDeployment.*/
   float m_ratio;
   /*! \brief The new padded frame dimensions of an input image. This is used for
   P2 and P3 object detection.*/

--- a/easy_perception_deployment/include/ort_cpp_lib/p2_ort_base.hpp
+++ b/easy_perception_deployment/include/ort_cpp_lib/p2_ort_base.hpp
@@ -74,7 +74,7 @@ private:
   /*! \brief The number of object text labels given an input label list.*/
   const uint16_t m_numClasses;
   /*! \brief The aspect ratio calculated from the dimension of an input image
-  frame, which is provided when the first input image is received by Processor.*/
+  frame, which is provided when the first input image is received by EasyPerceptionDeployment.*/
   float m_ratio;
   /*! \brief The new padded frame dimensions of an input image. This is used for
   P2 and P3 object detection.*/

--- a/easy_perception_deployment/include/ort_cpp_lib/p3_ort_base.hpp
+++ b/easy_perception_deployment/include/ort_cpp_lib/p3_ort_base.hpp
@@ -116,7 +116,7 @@ private:
   /*! \brief The number of object text labels given an input label list.*/
   const uint16_t m_numClasses;
   /*! \brief The aspect ratio calculated from the dimension of an input image
-  frame, which is provided when the first input image is received by Processor.*/
+  frame, which is provided when the first input image is received by EasyPerceptionDeployment.*/
   float m_ratio;
   /*! \brief The new padded frame dimensions of an input image. This is used for
   P2 and P3 object detection.*/

--- a/easy_perception_deployment/launch/run.launch.py
+++ b/easy_perception_deployment/launch/run.launch.py
@@ -20,8 +20,8 @@ def generate_launch_description():
     return LaunchDescription([
         launch_ros.actions.Node(
             package='easy_perception_deployment',
-            executable='processor',
+            executable='easy_perception_deployment',
             output='screen',
-            remappings=[('/processor/image_input', '/virtual_camera/image_raw')]
+            remappings=[('/easy_perception_deployment/image_input', '/virtual_camera/image_raw')]
             ),
     ])

--- a/easy_perception_deployment/src/main.cpp
+++ b/easy_perception_deployment/src/main.cpp
@@ -18,7 +18,7 @@
 #include "rclcpp/rclcpp.hpp"
 
 // EPD_UTILS LIB
-#include "epd_utils_lib/processor.hpp"
+#include "epd_utils_lib/easy_perception_deployment.hpp"
 
 int main(int argc, char * argv[])
 {

--- a/easy_perception_deployment/src/main.cpp
+++ b/easy_perception_deployment/src/main.cpp
@@ -25,9 +25,9 @@ int main(int argc, char * argv[])
   setlinebuf(stdout);
   rclcpp::init(argc, argv);
 
-  auto processor_node = std::make_shared<Processor>();
+  auto epd_node = std::make_shared<EasyPerceptionDeployment>();
 
-  rclcpp::spin(processor_node);
+  rclcpp::spin(epd_node);
   rclcpp::shutdown();
   return 0;
 }

--- a/easy_perception_deployment/test/test_easy_perception_deployment.cpp
+++ b/easy_perception_deployment/test/test_easy_perception_deployment.cpp
@@ -35,7 +35,7 @@ std::string PATH_TO_TEST_IMAGE(PATH_TO_PACKAGE "/test/nadezhda_diskant.jpg");
 std::string PATH_TO_TEST_COLORED_IMAGE(PATH_TO_PACKAGE "/test/colored_img.png");
 std::string PATH_TO_TEST_DEPTH_IMAGE(PATH_TO_PACKAGE "/test/depth_img.png");
 
-TEST(EPD_TestSuite, Test_Processor_P3Model_Tracking_Action)
+TEST(EPD_TestSuite, Test_EasyPerceptionDeployment_P3Model_Tracking_Action)
 {
   system(("rm -f " + PATH_TO_SESSION_CONFIG).c_str());
   system(("touch " + PATH_TO_SESSION_CONFIG).c_str());
@@ -48,7 +48,7 @@ TEST(EPD_TestSuite, Test_Processor_P3Model_Tracking_Action)
   system(("echo 4 >> " + PATH_TO_USECASE_CONFIG).c_str());
   system(("echo CSRT >> " + PATH_TO_USECASE_CONFIG).c_str());
 
-  auto processor_node = std::make_shared<Processor>();
+  auto epd_node = std::make_shared<EasyPerceptionDeployment>();
   cv::Mat rgb_frame = cv::imread(PATH_TO_TEST_IMAGE, cv::IMREAD_COLOR);
   cv::Mat depth_frame = cv::imread(PATH_TO_TEST_DEPTH_IMAGE, cv::IMREAD_UNCHANGED);
 
@@ -65,10 +65,10 @@ TEST(EPD_TestSuite, Test_Processor_P3Model_Tracking_Action)
   sensor_msgs::msg::Image::SharedPtr depth_msg =
     cv_bridge::CvImage(std_msgs::msg::Header(), "mono16", depth_frame).toImageMsg();
 
-  processor_node->process_tracking_callback(input_msg, depth_msg, camera_info);
+  epd_node->process_tracking_callback(input_msg, depth_msg, camera_info);
 }
 
-TEST(EPD_TestSuite, Test_Processor_P3Model_Localization_Action)
+TEST(EPD_TestSuite, Test_EasyPerceptionDeployment_P3Model_Localization_Action)
 {
   system(("rm -f " + PATH_TO_SESSION_CONFIG).c_str());
   system(("touch " + PATH_TO_SESSION_CONFIG).c_str());
@@ -80,7 +80,7 @@ TEST(EPD_TestSuite, Test_Processor_P3Model_Localization_Action)
   system(("touch " + PATH_TO_USECASE_CONFIG).c_str());
   system(("echo 3 >> " + PATH_TO_USECASE_CONFIG).c_str());
 
-  auto processor_node = std::make_shared<Processor>();
+  auto epd_node = std::make_shared<EasyPerceptionDeployment>();
   cv::Mat rgb_frame = cv::imread(PATH_TO_TEST_IMAGE, cv::IMREAD_COLOR);
   cv::Mat depth_frame = cv::imread(PATH_TO_TEST_DEPTH_IMAGE, cv::IMREAD_UNCHANGED);
 
@@ -97,10 +97,10 @@ TEST(EPD_TestSuite, Test_Processor_P3Model_Localization_Action)
   sensor_msgs::msg::Image::SharedPtr depth_msg =
     cv_bridge::CvImage(std_msgs::msg::Header(), "mono16", depth_frame).toImageMsg();
 
-  processor_node->process_localize_callback(input_msg, depth_msg, camera_info);
+  epd_node->process_localize_callback(input_msg, depth_msg, camera_info);
 }
 
-TEST(EPD_TestSuite, Test_Processor_P3Model_Classification_Action)
+TEST(EPD_TestSuite, Test_EasyPerceptionDeployment_P3Model_Classification_Action)
 {
   system(("rm -f " + PATH_TO_SESSION_CONFIG).c_str());
   system(("touch " + PATH_TO_SESSION_CONFIG).c_str());
@@ -112,16 +112,16 @@ TEST(EPD_TestSuite, Test_Processor_P3Model_Classification_Action)
   system(("touch " + PATH_TO_USECASE_CONFIG).c_str());
   system(("echo 0 >> " + PATH_TO_USECASE_CONFIG).c_str());
 
-  auto processor_node = std::make_shared<Processor>();
+  auto epd_node = std::make_shared<EasyPerceptionDeployment>();
   cv::Mat frame = cv::imread(PATH_TO_TEST_IMAGE, cv::IMREAD_COLOR);
 
   sensor_msgs::msg::Image::SharedPtr input_msg =
     cv_bridge::CvImage(std_msgs::msg::Header(), "bgr8", frame).toImageMsg();
 
-  processor_node->process_image_callback(input_msg);
+  epd_node->process_image_callback(input_msg);
 }
 
-TEST(EPD_TestSuite, Test_Processor_P2Model_Classification_Action)
+TEST(EPD_TestSuite, Test_EasyPerceptionDeployment_P2Model_Classification_Action)
 {
   system(("rm -f " + PATH_TO_SESSION_CONFIG).c_str());
   system(("touch " + PATH_TO_SESSION_CONFIG).c_str());
@@ -133,16 +133,16 @@ TEST(EPD_TestSuite, Test_Processor_P2Model_Classification_Action)
   system(("touch " + PATH_TO_USECASE_CONFIG).c_str());
   system(("echo 0 >> " + PATH_TO_USECASE_CONFIG).c_str());
 
-  auto processor_node = std::make_shared<Processor>();
+  auto epd_node = std::make_shared<EasyPerceptionDeployment>();
   cv::Mat frame = cv::imread(PATH_TO_TEST_IMAGE, cv::IMREAD_COLOR);
 
   sensor_msgs::msg::Image::SharedPtr input_msg =
     cv_bridge::CvImage(std_msgs::msg::Header(), "bgr8", frame).toImageMsg();
 
-  processor_node->process_image_callback(input_msg);
+  epd_node->process_image_callback(input_msg);
 }
 
-TEST(EPD_TestSuite, Test_Processor_P1Model_Classification_Action)
+TEST(EPD_TestSuite, Test_EasyPerceptionDeployment_P1Model_Classification_Action)
 {
   system(("rm -f " + PATH_TO_SESSION_CONFIG).c_str());
   system(("touch " + PATH_TO_SESSION_CONFIG).c_str());
@@ -154,13 +154,13 @@ TEST(EPD_TestSuite, Test_Processor_P1Model_Classification_Action)
   system(("touch " + PATH_TO_USECASE_CONFIG).c_str());
   system(("echo 0 >> " + PATH_TO_USECASE_CONFIG).c_str());
 
-  auto processor_node = std::make_shared<Processor>();
+  auto epd_node = std::make_shared<EasyPerceptionDeployment>();
   cv::Mat frame = cv::imread(PATH_TO_TEST_IMAGE, cv::IMREAD_COLOR);
 
   sensor_msgs::msg::Image::SharedPtr input_msg =
     cv_bridge::CvImage(std_msgs::msg::Header(), "bgr8", frame).toImageMsg();
 
-  processor_node->process_image_callback(input_msg);
+  epd_node->process_image_callback(input_msg);
 }
 
 int main(int argc, char ** argv)

--- a/easy_perception_deployment/test/test_easy_perception_deployment.cpp
+++ b/easy_perception_deployment/test/test_easy_perception_deployment.cpp
@@ -22,7 +22,7 @@
 #include "epd_utils_lib/epd_container.hpp"
 #include "sensor_msgs/msg/camera_info.hpp"
 #include "cv_bridge/cv_bridge.h"
-#include "epd_utils_lib/processor.hpp"
+#include "epd_utils_lib/easy_perception_deployment.hpp"
 
 std::string PATH_TO_SESSION_CONFIG(PATH_TO_PACKAGE "/data/session_config.txt");
 std::string PATH_TO_USECASE_CONFIG(PATH_TO_PACKAGE "/data/usecase_config.txt");


### PR DESCRIPTION
## Purpose of Pull Request

This pull request refactors the entire system to refer to the main ROS2 node name as `easy_perception_deployment`, rather than generic `processor`.