### PR TITLE
Use vendor packages instead of local installation

### DIFF
--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -15,8 +15,8 @@ jobs:
       # Use code-coverage
       CODE_COVERAGE: "codecov.io"
       # Use custom public docker image
+      UPSTREAM_WORKSPACE: onnxruntime.repos
       ISOLATION: docker
-      DOCKER_IMAGE: cardboardcode/epd-foxy-base:emd_compatible
       CODECOV_TOKEN: b56af58a-9b3b-49a9-800d-65746dbfb346
 
     runs-on: ubuntu-20.04

--- a/easy_perception_deployment/CMakeLists.txt
+++ b/easy_perception_deployment/CMakeLists.txt
@@ -14,13 +14,7 @@ if(NOT DEFINED CMAKE_SUPPRESS_DEVELOPER_WARNINGS)
   set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS 1 CACHE INTERNAL "No dev warnings")
 endif()
 
-# Include onnxruntime C++ API Library
-set(onnxruntime_INSTALL_PREFIX /usr/local)
-set(onnxruntime_INCLUDE_DIRS
-  ${onnxruntime_INSTALL_PREFIX}/include/onnxruntime
-  ${onnxruntime_INSTALL_PREFIX}/include/onnxruntime/core/session
-)
-find_library(onnxruntime_LIBS NAMES onnxruntime PATHS /usr/local/lib)
+find_package(epd_onnxruntime_vendor REQUIRED)
 
 # Json CPP libraries
 find_package(PkgConfig REQUIRED)
@@ -41,7 +35,6 @@ find_package(PCL REQUIRED)
 find_package(pcl_conversions REQUIRED)
 
 include_directories(include
-  ${onnxruntime_INCLUDE_DIRS}
   ${PCL_INCLUDE_DIRS}
 )
 
@@ -102,62 +95,63 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
 
   ament_add_gtest(epd_test_init test/test_init.cpp ${EPD_UTILS})
-  ament_target_dependencies(epd_test_init OpenCV cv_bridge)
-  target_link_libraries(epd_test_init ${onnxruntime_LIBS} ${JSONCPP_LIBRARIES})
+  ament_target_dependencies(epd_test_init epd_onnxruntime_vendor OpenCV cv_bridge)
+  target_link_libraries(epd_test_init ${JSONCPP_LIBRARIES})
 
   ament_add_gtest(epd_test_invalid_usecase test/test_invalid_usecase.cpp ${EPD_UTILS})
-  ament_target_dependencies(epd_test_invalid_usecase OpenCV cv_bridge)
-  target_link_libraries(epd_test_invalid_usecase ${onnxruntime_LIBS} ${JSONCPP_LIBRARIES})
+  ament_target_dependencies(epd_test_invalid_usecase epd_onnxruntime_vendor OpenCV cv_bridge)
+  target_link_libraries(epd_test_invalid_usecase ${JSONCPP_LIBRARIES})
 
   ament_add_gtest(epd_test_P2_counting_action test/p2u1a.cpp ${EPD_UTILS})
-  ament_target_dependencies(epd_test_P2_counting_action OpenCV cv_bridge)
-  target_link_libraries(epd_test_P2_counting_action ${onnxruntime_LIBS} ${JSONCPP_LIBRARIES})
+  ament_target_dependencies(epd_test_P2_counting_action epd_onnxruntime_vendor OpenCV cv_bridge)
+  target_link_libraries(epd_test_P2_counting_action ${JSONCPP_LIBRARIES})
 
   ament_add_gtest(epd_test_P2_counting_visualize test/p2u1v.cpp ${EPD_UTILS})
-  ament_target_dependencies(epd_test_P2_counting_visualize OpenCV cv_bridge)
-  target_link_libraries(epd_test_P2_counting_visualize ${onnxruntime_LIBS} ${JSONCPP_LIBRARIES})
+  ament_target_dependencies(epd_test_P2_counting_visualize epd_onnxruntime_vendor OpenCV cv_bridge)
+  target_link_libraries(epd_test_P2_counting_visualize ${JSONCPP_LIBRARIES})
 
   ament_add_gtest(epd_test_P2_colormatch_action test/p2u2a.cpp ${EPD_UTILS})
-  ament_target_dependencies(epd_test_P2_colormatch_action OpenCV cv_bridge)
-  target_link_libraries(epd_test_P2_colormatch_action ${onnxruntime_LIBS} ${JSONCPP_LIBRARIES})
+  ament_target_dependencies(epd_test_P2_colormatch_action epd_onnxruntime_vendor OpenCV cv_bridge)
+  target_link_libraries(epd_test_P2_colormatch_action ${JSONCPP_LIBRARIES})
 
   ament_add_gtest(epd_test_P3_counting_visualize test/p3u1v.cpp ${EPD_UTILS})
-  ament_target_dependencies(epd_test_P3_counting_visualize OpenCV cv_bridge)
-  target_link_libraries(epd_test_P3_counting_visualize ${onnxruntime_LIBS} ${JSONCPP_LIBRARIES})
+  ament_target_dependencies(epd_test_P3_counting_visualize epd_onnxruntime_vendor OpenCV cv_bridge)
+  target_link_libraries(epd_test_P3_counting_visualize ${JSONCPP_LIBRARIES})
 
   ament_add_gtest(epd_test_P3_colormatch_visualize test/p3u2v.cpp ${EPD_UTILS})
-  ament_target_dependencies(epd_test_P3_colormatch_visualize OpenCV cv_bridge)
-  target_link_libraries(epd_test_P3_colormatch_visualize ${onnxruntime_LIBS} ${JSONCPP_LIBRARIES})
+  ament_target_dependencies(epd_test_P3_colormatch_visualize epd_onnxruntime_vendor OpenCV cv_bridge)
+  target_link_libraries(epd_test_P3_colormatch_visualize ${JSONCPP_LIBRARIES})
 
   ament_add_gtest(epd_test_P3_colormatch_action test/p3u2a.cpp ${EPD_UTILS})
-  ament_target_dependencies(epd_test_P3_colormatch_action OpenCV cv_bridge)
-  target_link_libraries(epd_test_P3_colormatch_action ${onnxruntime_LIBS} ${JSONCPP_LIBRARIES})
+  ament_target_dependencies(epd_test_P3_colormatch_action epd_onnxruntime_vendor OpenCV cv_bridge)
+  target_link_libraries(epd_test_P3_colormatch_action ${JSONCPP_LIBRARIES})
 
   ament_add_gtest(epd_test_P3_localize_action test/p3u3a.cpp ${EPD_UTILS})
-  ament_target_dependencies(epd_test_P3_localize_action OpenCV cv_bridge)
-  target_link_libraries(epd_test_P3_localize_action ${onnxruntime_LIBS} ${JSONCPP_LIBRARIES})
+  ament_target_dependencies(epd_test_P3_localize_action epd_onnxruntime_vendor OpenCV cv_bridge)
+  target_link_libraries(epd_test_P3_localize_action ${JSONCPP_LIBRARIES})
 
   ament_add_gtest(epd_test_P3_localize_visualize test/p3u3v.cpp ${EPD_UTILS})
-  ament_target_dependencies(epd_test_P3_localize_visualize OpenCV cv_bridge)
-  target_link_libraries(epd_test_P3_localize_visualize ${onnxruntime_LIBS} ${JSONCPP_LIBRARIES})
+  ament_target_dependencies(epd_test_P3_localize_visualize epd_onnxruntime_vendor OpenCV cv_bridge)
+  target_link_libraries(epd_test_P3_localize_visualize ${JSONCPP_LIBRARIES})
 
   ament_add_gtest(epd_test_P3_tracking_visualize test/p3u4v.cpp ${EPD_UTILS})
-  ament_target_dependencies(epd_test_P3_tracking_visualize OpenCV cv_bridge)
-  target_link_libraries(epd_test_P3_tracking_visualize ${onnxruntime_LIBS} ${JSONCPP_LIBRARIES})
+  ament_target_dependencies(epd_test_P3_tracking_visualize epd_onnxruntime_vendor OpenCV cv_bridge)
+  target_link_libraries(epd_test_P3_tracking_visualize ${JSONCPP_LIBRARIES})
 
   ament_add_gtest(epd_test_P3_tracking_action test/p3u4a.cpp ${EPD_UTILS})
-  ament_target_dependencies(epd_test_P3_tracking_action OpenCV cv_bridge)
-  target_link_libraries(epd_test_P3_tracking_action ${onnxruntime_LIBS} ${JSONCPP_LIBRARIES})
+  ament_target_dependencies(epd_test_P3_tracking_action epd_onnxruntime_vendor OpenCV cv_bridge)
+  target_link_libraries(epd_test_P3_tracking_action ${JSONCPP_LIBRARIES})
 
   ament_add_gtest(epd_test_easy_perception_deployment test/test_easy_perception_deployment.cpp ${EPD_UTILS})
-  ament_target_dependencies(epd_test_easy_perception_deployment rclcpp std_msgs sensor_msgs epd_msgs OpenCV cv_bridge message_filters pcl_conversions)
-  target_link_libraries(epd_test_easy_perception_deployment ${onnxruntime_LIBS} ${JSONCPP_LIBRARIES})
+  ament_target_dependencies(epd_test_easy_perception_deployment epd_onnxruntime_vendor rclcpp std_msgs sensor_msgs epd_msgs OpenCV cv_bridge message_filters pcl_conversions)
+  target_link_libraries(epd_test_easy_perception_deployment ${JSONCPP_LIBRARIES})
 
 endif()
 
 add_executable(easy_perception_deployment src/main.cpp ${EPD_UTILS})
 ament_target_dependencies(
   easy_perception_deployment
+  epd_onnxruntime_vendor
   rclcpp
   std_msgs
   sensor_msgs
@@ -168,7 +162,7 @@ ament_target_dependencies(
   message_filters
   pcl_conversions
 )
-target_link_libraries(easy_perception_deployment ${onnxruntime_LIBS} ${PCL_LIBRARIES} ${JSONCPP_LIBRARIES})
+target_link_libraries(easy_perception_deployment ${PCL_LIBRARIES} ${JSONCPP_LIBRARIES})
 
 
 install(TARGETS

--- a/easy_perception_deployment/CMakeLists.txt
+++ b/easy_perception_deployment/CMakeLists.txt
@@ -51,12 +51,13 @@ if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/data/model/MaskRCNN-10.onnx")
   message(AUTHOR_WARNING "Pretrained models are downloaded.")
 else()
   message(AUTHOR_WARNING "Downloading pretrained ONNX model from ONNX Model Zoo.")
-  execute_process(COMMAND wget
-  https://github.com/onnx/models/raw/main/vision/object_detection_segmentation/faster-rcnn/model/FasterRCNN-10.onnx
-  --directory-prefix=${CMAKE_CURRENT_LIST_DIR}/data/model/)
-  execute_process(COMMAND wget
+  file(DOWNLOAD https://github.com/onnx/models/raw/master/vision/classification/squeezenet/model/squeezenet1.1-7.onnx
+    ${CMAKE_CURRENT_LIST_DIR}/data/model/squeezenet1.1-7.onnx)
+  file(DOWNLOAD https://github.com/onnx/models/raw/main/vision/object_detection_segmentation/faster-rcnn/model/FasterRCNN-10.onnx
+    ${CMAKE_CURRENT_LIST_DIR}/data/model/FasterRCNN-10.onnx)
+  file(DOWNLOAD
   https://github.com/onnx/models/raw/main/vision/object_detection_segmentation/mask-rcnn/model/MaskRCNN-10.onnx
-  --directory-prefix=${CMAKE_CURRENT_LIST_DIR}/data/model/)
+    ${CMAKE_CURRENT_LIST_DIR}/data/model/MaskRCNN-10.onnx)
 endif()
 
 # Check if CUDA is available in local onnxruntime build

--- a/easy_perception_deployment/CMakeLists.txt
+++ b/easy_perception_deployment/CMakeLists.txt
@@ -89,6 +89,7 @@ if(BUILD_TESTING)
   list(APPEND AMENT_LINT_AUTO_EXCLUDE
     ament_cmake_pep257
     ament_cmake_flake8
+    ament_cmake_lint_cmake
   )
 
   ament_lint_auto_find_test_dependencies()

--- a/easy_perception_deployment/package.xml
+++ b/easy_perception_deployment/package.xml
@@ -15,6 +15,7 @@
   <build_depend>cv_bridge</build_depend>
   <build_depend>pcl_conversions</build_depend>
   <build_depend>epd_msgs</build_depend>
+  <build_depend>epd_onnxruntime_vendor</build_depend>
   <build_depend>libopencv-dev</build_depend>
 
   <exec_depend>cv_bridge</exec_depend>

--- a/easy_perception_deployment/package.xml
+++ b/easy_perception_deployment/package.xml
@@ -17,6 +17,7 @@
   <build_depend>epd_msgs</build_depend>
   <build_depend>epd_onnxruntime_vendor</build_depend>
   <build_depend>libopencv-dev</build_depend>
+  <build_depend>tf2</build_depend>
 
   <exec_depend>cv_bridge</exec_depend>
   <exec_depend>libopencv-dev</exec_depend>

--- a/onnxruntime.repos
+++ b/onnxruntime.repos
@@ -1,0 +1,5 @@
+repositories:
+  epd_onnxruntime_vendor:
+    type: git
+    url: https://github.com/Briancbn/epd_onnxruntime_vendor
+    version: main


### PR DESCRIPTION
Signed-off-by: Chen Bainian <chenbn@artc.a-star.edu.sg>

Using `epd_onnxruntime_vendor` package instead of local installation of onnx runtime. (Please note that local installation is still compatible)

## Vendor Package

epd_onnxruntime_vendor: https://github.com/Briancbn/epd_onnxruntime_vendor

Following how it was done in https://github.com/ros2/yaml_cpp_vendor

The vendor package uses `ExternalProject_Add` to make the `onnxruntime` dependencies, if it is not found locally.

When sourcing `setup.bash` of the vendor package,  [an additional script](https://github.com/Briancbn/epd_onnxruntime_vendor/blob/main/env_hook/epd_onnxruntime_vendor_library_path.sh) is called to include the newly added library in to the `LD_LIBRARY_PATH` to avoid runtime linking error.

When calling `find_package(epd_onnxruntime_vendor)` from another package (e.g. epd), [the following cmake extra script](https://github.com/Briancbn/epd_onnxruntime_vendor/blob/main/epd_onnxruntime_vendor-extras.cmake.in) will be called to first check for local installation. If there is no local installation, it will uses the binaries built within the vendor package.

### Naming

Since [`onnxruntime_vendor`](https://github.com/ms-iot/ros_msft_onnx) already exist, but cannot be used for EPD due to version difference and only works with released binaries, this packages is named to be `epd_onnxruntime_vendor` instead.

### How to use

Simply download the vendor repository and compiling it using `colcon build`. For GPU usage, an additional `USE_CUDA` variable is provided.
```bash
colcon build --cmake-args -DUSE_CUDA=ON
```

Make sure that the vendor package is sourced or in the same workspace before building the EPD pacakges.

### Limitations
- version is hard set to `36dc057913f968566eaa1646cb5db41d8c5e7654`. ([ref](https://github.com/Briancbn/epd_onnxruntime_vendor/blob/0b7f34ac1cb2197032b596fbdc90210e3ce6f111/CMakeLists.txt#L51))
  - CMake variables has changed between the versions release subsequently and the current one used. Additional work is needed to work with the latest version.
- No Windows support. Not on priority, but it's doable.
- It takes 10min to build the package (5min just to download)
  - process can be monitored after appending `--event-handlers=console-direct+` to `colcon build` command

### How to test

1.With local installtion setup using `script`

`colcon build` of the vendor package shouldn't take long and it should skip the building from source using `ExternalProject_Add` 

2. Without local installation

This might be easier to test in a clean docker, since I am not sure how to uninstall a locally installed `onnxruntime`.
`colcon build` (CPU / GPU) should takes about 10min to complete.

In both cases, you can see the following warning when building both the vendor and epd packages.
```bash
Found onnxruntime in path ...
```
Verify if the path is correct.

## Next Step

Please let me know if the following can be reproduced and is something that EPD would benefit.
Additional actions:
- [ ] Update the setup script
- [x] Update the tutorial
- [ ] Update Dockerfile
- [x] Update CI
- [ ] Transfer the vendor package into ros-industrial Github Organization
- [ ] Merge this PR and all the related PR
- [ ] Release to rosdistro