### PR TITLE
Update documentation link and add in setup instructions for onnxruntime using vendor

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,19 @@ cd $HOME
 mkdir -p epd_ros2_ws/src && cd epd_ros2_ws/src
 
 # Download fast and shallow copy of easy_perception_deployment
-git clone https://github.com/ros-industrial/easy_perception_deployment.git \
---depth 1 --single-branch
-cd easy_perception_deployment/easy_perception_deployment
+git clone https://github.com/ros-industrial/epd_onnxruntime_vendor.git
+git clone https://github.com/ros-industrial/easy_perception_deployment.git
+
+# Install dependencies
+cd $HOME/epd_ros2_ws/
+source /opt/ros/foxy/setup.bash
+rosdep install --from-paths src --ignore-src -y
+
+# Build the ROS2 workspace
+colcon build
 
 # Start up GUI interface.
+cd easy_perception_deployment
 bash run.bash
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ rosdep install --from-paths src --ignore-src -y
 colcon build
 
 # Start up GUI interface.
-cd easy_perception_deployment
+cd src/easy_perception_deployment/easy_perception_deployment
 bash run.bash
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ bash run.bash
 
 ## **Docs**
 
-[Check out the full documentation here.](https://epd-docs.readthedocs.io/en/latest/)
+[Check out the full documentation here.](https://easy-perception-deployment.readthedocs.io/en/latest/)
 
 ## **Contributions & Feedback**
 


### PR DESCRIPTION
Requires https://github.com/ros-industrial/epd_docs/pull/3 to be merged first.

- Update documentation link.
- Add instructions for using the vendor package instead.