### PR TITLE
Fix pipeline: deprecated runs-on, industrial_ci and more

### DIFF
--- a/.github/workflows/cli_ci_action.yml
+++ b/.github/workflows/cli_ci_action.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/cli_ci_action.yml
+++ b/.github/workflows/cli_ci_action.yml
@@ -12,8 +12,6 @@ jobs:
       QT_QPA_PLATFORM: "offscreen"
 
     runs-on: ubuntu-latest
-    container:
-      image: ubuntu:20.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/cli_ci_action.yml
+++ b/.github/workflows/cli_ci_action.yml
@@ -11,7 +11,9 @@ jobs:
     env:
       QT_QPA_PLATFORM: "offscreen"
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:20.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/gui_ci_action.yml
+++ b/.github/workflows/gui_ci_action.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/gui_ci_action.yml
+++ b/.github/workflows/gui_ci_action.yml
@@ -12,8 +12,6 @@ jobs:
       QT_QPA_PLATFORM: "offscreen"
 
     runs-on: ubuntu-latest
-    container:
-      image: ubuntu:20.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/gui_ci_action.yml
+++ b/.github/workflows/gui_ci_action.yml
@@ -11,7 +11,9 @@ jobs:
     env:
       QT_QPA_PLATFORM: "offscreen"
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:20.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -19,8 +19,6 @@ jobs:
       ISOLATION: docker
 
     runs-on: ubuntu-latest
-    container:
-      image: ubuntu:20.04
     steps:
       - uses: actions/checkout@v2
       # Fetch/store the directory used by ccache before/after the ci run
@@ -29,7 +27,7 @@ jobs:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-${{ matrix.env.ROS_DISTRO }}-${{ matrix.env.ROS_REPO }}
       # Run industrial_ci
-      - uses: 'cardboardcode/industrial_ci@pr-coverage'
+      - uses: 'ros-industrial/industrial_ci@master'
         env: ${{ matrix.env }}
       # Generate and upload code coverage report to codecov.
       - uses: codecov/codecov-action@v5

--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       # Fetch/store the directory used by ccache before/after the ci run
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-${{ matrix.env.ROS_DISTRO }}-${{ matrix.env.ROS_REPO }}
@@ -32,6 +32,6 @@ jobs:
       - uses: 'cardboardcode/industrial_ci@pr-coverage'
         env: ${{ matrix.env }}
       # Generate and upload code coverage report to codecov.
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -10,10 +10,13 @@ jobs:
         env:
           - {ROS_DISTRO: foxy, ROS_REPO: testing}
           - {ROS_DISTRO: foxy, ROS_REPO: main}
+          - ROS_DISTRO: foxy
+            ROS_REPO: main
+            TARGET_CMAKE_ARGS: "-DCMAKE_C_FLAGS='--coverage' -DCMAKE_CXX_FLAGS='--coverage'"
+            AFTER_SCRIPT: "./coverage.sh ci"
+            CODE_COVERAGE: "codecov.io"
     env:
       CCACHE_DIR: /github/home/.ccache
-      # Use code-coverage
-      CODE_COVERAGE: "codecov.io"
       # Use custom public docker image
       UPSTREAM_WORKSPACE: onnxruntime.repos
       ISOLATION: shell
@@ -32,6 +35,13 @@ jobs:
       - uses: 'ros-industrial/industrial_ci@master'
         env: ${{ matrix.env }}
       # Generate and upload code coverage report to codecov.
-      - uses: codecov/codecov-action@v5
+      - name: Install dependency for Codecov
+        if: ${{ matrix.env.CODE_COVERAGE == 'codecov.io' }}
+        run: sudo apt install curl git -y
+      - name: Upload coverage reports to Codecov
+        if: ${{ matrix.env.CODE_COVERAGE == 'codecov.io' }}
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.info
+          fail_ci_if_error: true

--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -16,9 +16,11 @@ jobs:
       CODE_COVERAGE: "codecov.io"
       # Use custom public docker image
       UPSTREAM_WORKSPACE: onnxruntime.repos
-      ISOLATION: docker
+      ISOLATION: shell
 
     runs-on: ubuntu-latest
+    container:
+      image: ubuntu:20.04
     steps:
       - uses: actions/checkout@v2
       # Fetch/store the directory used by ccache before/after the ci run

--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -18,7 +18,9 @@ jobs:
       UPSTREAM_WORKSPACE: onnxruntime.repos
       ISOLATION: docker
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:20.04
     steps:
       - uses: actions/checkout@v2
       # Fetch/store the directory used by ccache before/after the ci run

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# To use this locally, go to the root of your workspace
+# cd ~/<workspace-name>/
+# Then run ./src/easy_manipulation_deployment/coverage.sh html
+# Coverage report will be generate automatically
+
+# Enable branch coverage for local report
+# ./src/easy_manipulation_deployment/coverage.sh html
+
+if [ "$1" = "ci" ]; then
+  cd ~/target_ws || return 1
+fi
+
+branch_command=()
+branch_html_command=()
+if [ "$2" = "--branch" ]; then
+  branch_command=(--rc "lcov_branch_coverage=1")
+  branch_html_command=(--branch-coverage)
+fi
+
+package_name="easy_perception_deployment"
+
+ignored_files="*/test/*"
+
+# Install LCOV
+if [ "$(dpkg-query -W -f='${Status}' lcov 2>/dev/null | grep -c 'ok installed')" -eq 0 ];
+then
+  sudo apt-get install -y -qq lcov
+fi
+
+
+# Capture initial coverage info
+lcov --capture --initial \
+     --directory build \
+     --output-file initial_coverage.info "${branch_command[@]}" | grep -ve "^Processing"
+# Capture tested coverage info
+lcov --capture \
+     --directory build \
+     --output-file test_coverage.info "${branch_command[@]}" | grep -ve "^Processing"
+# Combine two report (exit function  when none of the records are valid)
+lcov --add-tracefile initial_coverage.info \
+     --add-tracefile test_coverage.info \
+     --output-file coverage.info "${branch_command[@]}" || return 0 \
+  && rm initial_coverage.info test_coverage.info
+# Extract repository files
+lcov --extract coverage.info "$(pwd)/src/$package_name/*" \
+     --output-file coverage.info "${branch_command[@]}" | grep -ve "^Extracting"
+# Filter out ignored files
+lcov --remove coverage.info "$ignored_files" \
+     --output-file coverage.info "${branch_command[@]}" | grep -ve "^removing"
+if [ "$1" = "ci" ]; then
+  # Some sed magic to remove identifiable absolute path
+  sed -i "s~$(pwd)/src/$package_name/~~g" coverage.info
+  lcov --list coverage.info "${branch_command[@]}"
+
+  cd - || return 1
+  cp -r ~/target_ws/coverage.info .
+
+elif [ "$1" = "html" ]; then
+  genhtml "${branch_html_command[@]}" coverage.info -o coverage
+fi


### PR DESCRIPTION
Fix outdated pipeline
- Change runs-on to `ubuntu-latest` due to 20.04 deprecation https://github.com/actions/runner-images/issues/11101
- Switch to using industrial CI master
- Update cache and setup-python GHA versions.
- Migrate coverage code to industrial CI `AFTER_SCRIPT`.